### PR TITLE
Add libWrapper support

### DIFF
--- a/scripts/RoofsLayer.js
+++ b/scripts/RoofsLayer.js
@@ -290,12 +290,9 @@ export default class RoofsLayer extends CanvasLayer {
           return update.call(this, origUpdate.bind(this), ...arguments);
         };
       }
-
-      canvas.sight.update();
     }
     else {
       Hooks.on("sightRefresh", () => RoofsLayer._sightUpdate());
-      canvas.sight.refresh();
     }
   }
 

--- a/scripts/roofs.js
+++ b/scripts/roofs.js
@@ -25,6 +25,9 @@ Hooks.once('canvasInit', () => {
  *  Apply patches to core methods
  */
 Hooks.once('ready', () => {
+  if (!game.modules.get("lib-wrapper")?.active && game.user.isGM)
+      ui.notifications.warn("The 'Roofs & Overhead Tiles' module recommends to install and activate the 'libWrapper' module.");
+
   RoofsLayer._patchDrag();
   RoofsLayer._patchSight();
 });

--- a/scripts/roofs.js
+++ b/scripts/roofs.js
@@ -24,12 +24,16 @@ Hooks.once('canvasInit', () => {
 /**
  *  Apply patches to core methods
  */
+Hooks.once('init', () => {
+  RoofsLayer._patchDrag();
+  RoofsLayer._patchSight();
+});
+
 Hooks.once('ready', () => {
   if (!game.modules.get("lib-wrapper")?.active && game.user.isGM)
       ui.notifications.warn("The 'Roofs & Overhead Tiles' module recommends to install and activate the 'libWrapper' module.");
 
-  RoofsLayer._patchDrag();
-  RoofsLayer._patchSight();
+  canvas.sight.update();
 });
 
 /**


### PR DESCRIPTION
Use libWrapper to patch functions if possible; otherwise patch as before. Gives the GM the recommendation to enable the libWrapper module.

Also patch in _init_ hook; _ready_ is too late because `PlaceableObject._createInteractionManager()` is called on placeables that are already in the scene before that.